### PR TITLE
Restrict user account creation to social_auth only

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -284,7 +284,7 @@ FEATURES = {
     # Special Exams, aka Timed and Proctored Exams
     'ENABLE_SPECIAL_EXAMS': False,
 
-    'ORGANIZATIONS_APP': True,
+    'ORGANIZATIONS_APP': False,
 
     # Show the language selector in the header
     'SHOW_HEADER_LANGUAGE_SELECTOR': False,

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -425,6 +425,7 @@ class AccountValidationError(Exception):
     """
     Used in account creation views to raise exceptions with details about specific invalid fields
     """
+
     def __init__(self, message, field):
         super(AccountValidationError, self).__init__(message)
         self.field = field
@@ -583,7 +584,10 @@ def process_survey_link(survey_link, user):
     return survey_link.format(UNIQUE_ID=unique_id_for_user(user))
 
 
-def do_create_account(form, custom_form=None):
+# [COLARAZ_CUSTOM]
+# To restrict user creation from open edX registeration flow while
+# allowing social_auth to create them.
+def do_create_account(form, custom_form=None, req_via_social_auth=False):
     """
     Given cleaned post variables, create the User and UserProfile objects, as well as the
     registration for this user.
@@ -593,7 +597,7 @@ def do_create_account(form, custom_form=None):
     Note: this function is also used for creating test users.
     """
     # Check if ALLOW_PUBLIC_ACCOUNT_CREATION flag turned off to restrict user account creation
-    if not configuration_helpers.get_value(
+    if not req_via_social_auth and not configuration_helpers.get_value(
             'ALLOW_PUBLIC_ACCOUNT_CREATION',
             settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)
     ):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -285,7 +285,7 @@ FEATURES = {
     'MILESTONES_APP': False,
 
     # Organizations application flag
-    'ORGANIZATIONS_APP': True,
+    'ORGANIZATIONS_APP': False,
 
     # Prerequisite courses feature flag
     'ENABLE_PREREQUISITE_COURSES': False,

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -105,6 +105,11 @@ def create_account_with_params(request, params):
     # params is request.POST, that results in a dict containing lists of values
     params = dict(params.items())
 
+    # [COLARAZ_CUSTOM]
+    # To restrict user creation from open edX registeration flow while 
+    # allowing social_auth to create them.
+    req_via_social_auth = params.has_key('social_auth_provider')
+    
     # allow to define custom set of required/optional/hidden fields via configuration
     extra_fields = configuration_helpers.get_value(
         'REGISTRATION_EXTRA_FIELDS',
@@ -159,7 +164,7 @@ def create_account_with_params(request, params):
     # Perform operations within a transaction that are critical to account creation
     with outer_atomic(read_committed=True):
         # first, create the account
-        (user, profile, registration) = do_create_account(form, custom_form)
+        (user, profile, registration) = do_create_account(form, custom_form, req_via_social_auth)
 
         third_party_provider, running_pipeline = _link_user_to_third_party_provider(
             is_third_party_auth_enabled, third_party_auth_credentials_in_api, user, request, params,


### PR DESCRIPTION
### Story Link:
https://edlyio.atlassian.net/browse/EDE-326

### Description
As Colaraz has implemented OAUTH based IdP, the User was able to register new accounts through the open edX registration flow. 
This PR will restrict the creation of new accounts through open edX.

We have to use 'ALLOW_PUBLIC_ACCOUNT_CREATION' feature with some customization in its usage.
By default 'ALLOW_PUBLIC_ACCOUNT_CREATION' restricts us to create an account through open edX registration as well as through IdP, which in our case wasn't a desired functionality.

### Flags to be changed
In lms.env.json under FEATURES:
"ALLOW_PUBLIC_ACCOUNT_CREATION" : false
