### PR TITLE
moving auth backend to colaraz app and filtering on org short name

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -228,7 +228,7 @@ def get_course_enrollments(user, org_whitelist, org_blacklist):
         # To restrict users from viewing unallowed courses. 
         if settings.FEATURES.get('ORGANIZATIONS_APP', False):
             if org_whitelist and OrganizationCourse.objects.filter(course_id=str(course_overview), 
-                                                                   organization__name__in=org_whitelist, 
+                                                                   organization__short_name__in=org_whitelist,
                                                                    active=True):
                 yield enrollment
             else:

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -685,12 +685,12 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 ##### Third-party auth options ################################################
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
+        'openedx.features.colaraz_features.auth_backend.ColarazIdentityServer',
         'social_core.backends.google.GoogleOAuth2',
         'social_core.backends.linkedin.LinkedinOAuth2',
         'social_core.backends.facebook.FacebookOAuth2',
         'social_core.backends.azuread.AzureADOAuth2',
         'third_party_auth.identityserver3.IdentityServer3',
-        'third_party_auth.colaraz.ColarazIdentityServer',
         'third_party_auth.saml.SAMLAuthBackend',
         'third_party_auth.lti.LTIAuthBackend',
     ])

--- a/openedx/features/colaraz_features/auth_backend.py
+++ b/openedx/features/colaraz_features/auth_backend.py
@@ -1,6 +1,7 @@
+import logging
+
 from django.utils.functional import cached_property
 from social_core.exceptions import AuthException
-import logging
 
 from openedx.core.djangoapps.theming.helpers import get_current_request
 from third_party_auth.identityserver3 import IdentityServer3
@@ -48,7 +49,7 @@ class ColarazIdentityServer(IdentityServer3):
         if not domain:
             LOGGER.exception("Domain not found in request attributes")
             raise AuthException("Colaraz", "Error while authentication")
-        elif not domain.startswith(user_site_domain.lower()):
+        elif user_site_domain.lower() not in domain:
             LOGGER.exception("User can only login through {} site".format(user_site_domain))
             raise AuthException("Colaraz", "Your account belongs to {}".format(user_site_domain))
 


### PR DESCRIPTION
Moving Colaraz's auth backend to colaraz_features app and filtering courses on the bases of organization short name.