### PR TITLE
Turning off ENABLE_CREATOR_GROUP flag

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -129,7 +129,7 @@ SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
 ########################## AUTHOR PERMISSION #######################
-FEATURES['ENABLE_CREATOR_GROUP'] = True
+FEATURES['ENABLE_CREATOR_GROUP'] = False
 
 ################################# DJANGO-REQUIRE ###############################
 

--- a/openedx/features/colaraz_features/middlewares.py
+++ b/openedx/features/colaraz_features/middlewares.py
@@ -3,7 +3,6 @@ import logging
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponseRedirect, Http404
-from django.urls import reverse
 from six.moves.urllib.parse import urlencode
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers


### PR DESCRIPTION
This PR contains the following content:
* Removing an unused import 
* Turning off ENABLE_CREATOR_GROUP flag (now developer need to turn it on by using a private.py for devstack) 