### PR TITLE
fix: Fixes 500 errors and the bug of letting invalid domains pass.

### DIFF
--- a/openedx/features/colaraz_features/api/serializers.py
+++ b/openedx/features/colaraz_features/api/serializers.py
@@ -13,8 +13,8 @@ from openedx.features.colaraz_features.helpers import (
 
 
 class SiteOrgSerializer(serializers.Serializer):
-    site_domain = DomainField()
-    site_name = serializers.CharField(max_length=255)
+    site_domain = DomainField(max_length=100)
+    site_name = serializers.CharField(max_length=50)
     site_theme = serializers.CharField(max_length=255, default=settings.DEFAULT_SITE_THEME)
     org_name = serializers.CharField(max_length=255)
     org_short_name = serializers.SlugField(max_length=255)

--- a/openedx/features/colaraz_features/api/validators.py
+++ b/openedx/features/colaraz_features/api/validators.py
@@ -8,12 +8,17 @@ from django.utils.translation import gettext_lazy as _
 
 
 class DomainValidator(RegexValidator):
-    ul = '\u00a1-\uffff'  # unicode letters range (must not be a raw string)
+    """
+    Domain name validation logic is contained withing this class.
 
+    Domain names must only use the letters a to z, the numbers 0 to 9, and the hyphen (-) character.
+    If the hyphen character is used in a domain name, it cannot be the first character in the name.
+    For example, -example.com would not be allowed, but ex-ample.com would be.
+    """
     # Hostname e.g. example in example.com
-    hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]{0,61}[a-z' + ul + r'0-9])?'
+    hostname_re = r'[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?'
     # Domain e.g. .com in example.com
-    domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]{1,63}(?<!-))+'
+    domain_re = r'(?:\.(?!-)[a-z0-9-]{1,63}(?<!-))+'
     host_re = '^(' + hostname_re + domain_re + '|localhost)$'
 
     regex = re.compile(host_re, re.IGNORECASE)

--- a/openedx/features/colaraz_features/helpers.py
+++ b/openedx/features/colaraz_features/helpers.py
@@ -138,7 +138,8 @@ def create_site_configurations(sites, organization, university_name, platform_na
                 PLATFORM_NAME=platform_name,
                 platform_name=platform_name,
                 site_domain=site.domain,
-                site_name=university_name,
+                SITE_NAME=site.domain,
+                university=university_name,
                 course_org_filters=remove_duplicates(organizations + [organization.short_name]),
                 **(
                     {


### PR DESCRIPTION
__Description:__

This PR contains fixes for the following

1. 500 errors on the staging server. This error was being caused by `Site.name` max length constraint, I have added the same constraint on the serializer so that we catch such error invalidation.
2. Domain name validation was letting invalid domains pass through, updated the validation logic so that only valid domains are passing through the validation logic.
