### PR TITLE
Secondary organizations on course create and setting page

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -5,6 +5,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
         var CreateCourseUtils = new CreateCourseUtilsFactory({
             name: '.new-course-name',
             org: '.new-course-org',
+            secondaryOrg: '.new-course-secondary-org',
             number: '.new-course-number',
             run: '.new-course-run',
             save: '.new-course-save',
@@ -42,7 +43,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
         var saveNewCourse = function(e) {
             e.preventDefault();
 
-            if (CreateCourseUtils.hasInvalidRequiredFields()) {
+	        if (CreateCourseUtils.hasInvalidRequiredFields()) {
                 return;
             }
 
@@ -51,12 +52,14 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
             var org = $newCourseForm.find('.new-course-org').val();
             var number = $newCourseForm.find('.new-course-number').val();
             var run = $newCourseForm.find('.new-course-run').val();
+            var secondary_org_list = $newCourseForm.find('.new-course-secondary-org').val();
 
             var course_info = {
                 org: org,
                 number: number,
                 display_name: display_name,
-                run: run
+                run: run,
+                secondary_orgs: secondary_org_list
             };
 
             analytics.track('Created a Course', course_info);
@@ -87,6 +90,8 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
         var makeCancelHandler = function(addType) {
             return function(e) {
                 e.preventDefault();
+                $('.new-course-org').val('').find('option').not(':first').remove();
+                $('.new-course-secondary-org').empty();
                 $('.new-' + addType + '-button').removeClass('is-disabled').attr('aria-disabled', false);
                 $('.wrapper-create-' + addType).removeClass('is-shown');
                 // Clear out existing fields and errors
@@ -169,7 +174,22 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
             };
         };
 
+        var setupSecondaryOrgAutocomplete = function(e) {
+            $('.new-course-secondary-org').empty();
+            $.each(e.target.options, function(i, option) {
+                if (e.target.value && option.value && e.target.value !== option.value) {
+                    $('.new-course-secondary-org').append(
+                        $('<option>', {
+                            value: option.value,
+                            text: option.text
+                      })
+                    );
+                }
+            });
+        };
+
         var onReady = function() {
+            $('.new-course-org').bind('change', setupSecondaryOrgAutocomplete);
             $('.new-course-button').bind('click', addNewCourse);
             $('.new-library-button').bind('click', addNewLibrary);
 

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -32,7 +32,8 @@ define(['backbone', 'underscore', 'gettext', 'js/models/validation_helpers', 'js
                 entrance_exam_minimum_score_pct: '50',
                 learning_info: [],
                 instructor_info: {},
-                self_paced: null
+                self_paced: null,
+                secondary_organizations: []
             },
 
             validate: function(newattrs) {

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -35,6 +35,12 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
                    this.$el.find('#course-name').val(this.model.get('run'));
                    this.$el.find('.set-date').datepicker({dateFormat: 'm/d/yy'});
 
+                   var secondary_organizations = this.model.get('secondary_organizations');
+                   $.each(this.$el.find('#secondary-organizations option'), function(i, option) {
+                       if (secondary_organizations.includes(option.value))
+                           option.selected = true;
+                   });
+
         // Avoid showing broken image on mistyped/nonexistent image
                    this.$el.find('img').error(function() {
                        $(this).hide();
@@ -181,7 +187,8 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
                    course_settings_learning_fields: 'course-settings-learning-fields',
                    add_course_learning_info: 'add-course-learning-info',
                    add_course_instructor_info: 'add-course-instructor-info',
-                   course_learning_info: 'course-learning-info'
+                   course_learning_info: 'course-learning-info',
+                   secondary_organizations: 'secondary-organizations'
                },
 
                addLearningFields: function() {
@@ -231,6 +238,9 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
                        var learningInfo = this.model.get('learning_info');
                        learningInfo[index] = value;
                        this.showNotificationBar();
+                       break;
+                   case 'secondary-organizations':
+                       this.model.set('secondary_organizations', this.$el.find('#secondary-organizations').val())
                        break;
                    case 'course-instructor-name-' + index:
                    case 'course-instructor-title-' + index:

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -676,6 +676,7 @@
       display: block;
     }
 
+    .new-course-secondary-org,
     .new-course-org,
     .new-course-number,
     .new-course-name,

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -505,6 +505,16 @@
         }
       }
     }
+    // specific fields - course details
+    &.course_details {
+      select {
+        width: 100%;
+      }
+
+      #secondary-organizations {
+        height: ($baseline*6)
+      }
+    }
 
     // specific fields - overview
     #field-course-overview,

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -91,6 +91,18 @@ from openedx.core.djangolib.js_utils import (
                   <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
                 </li>
 
+                 <li class="field text required">
+                  <label for="new-course-secondary-org">${_("Secondary Organizations")}</label>
+                  <select class="new-course-secondary-org" id="new-course-secondary-org" type="text" name="new-course-secondary-org" aria-describedby="tip-new-course-secondary-org tip-error-new-course-secondary-org" multiple>
+                  </select>
+
+                  <span class="tip" id="tip-new-course-secondary-org">${Text(_("Link this course with multiple organizations.{strong_start} Note: It is not required, you can edit it later.{strong_end}")).format(
+                      strong_start=HTML('<strong>'),
+                      strong_end=HTML('</strong>'),
+                  )}</span>
+                  <span class="tip tip-error is-hiding" id="tip-error-new-course-secondary-org"></span>
+                </li>
+
                 <li class="field text required" id="field-course-number">
                   <label for="new-course-number">${_("Course Number")}</label>
                   ## Translators: This is an example for the number used to identify a course,

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -203,9 +203,9 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             </ol>
           </fieldset>
         </div>
-        
+
         <hr class="divide" />
-        
+
         <div id="schedule" class="group-settings schedule">
           <header>
             <h2 class="title-2">${_('Course Schedule')}</h2>
@@ -309,6 +309,15 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 % endfor
               </select>
               <span class="tip tip-stacked">${_("Identify the course language here. This is used to assist users find courses that are taught in a specific language. It is also used to localize the 'From:' field in bulk emails.")}</span>
+            </li>
+            <li class="field" id="field-secondary-organizations">
+              <label for="secondary-organizations">${_("Secondary Organizations")}</label>
+              <select id="secondary-organizations" multiple>
+                % for org in available_secondary_organizations:
+                  <option value="${org}">${org}</option>
+                % endfor
+              </select>
+              <span class="tip tip-stacked">${_("Secondary organizations to link this course with multiple organizations.")}</span>
             </li>
           </ol>
         </div>

--- a/common/djangoapps/util/organizations_helpers.py
+++ b/common/djangoapps/util/organizations_helpers.py
@@ -103,3 +103,17 @@ def organizations_enabled():
     Returns boolean indication if organizations app is enabled on not.
     """
     return settings.FEATURES.get('ORGANIZATIONS_APP', False)
+
+
+def get_secondary_org_names_of_course(course_id, primary_org_name):
+    """
+    Returns list of all secondary organizations names linked with the course.
+    """
+    if not organizations_enabled():
+        return []
+    from organizations import api as organizations_api
+    all_organizations = organizations_api.get_course_organizations(course_id)
+
+    # exclude primary organization from the list
+    secondary_organizations = [org['name'] for org in all_organizations if not (org['name'] == primary_org_name)]
+    return secondary_organizations


### PR DESCRIPTION
**Ticket Link:** https://edlyio.atlassian.net/browse/EDE-358

**Description:** 

- Staff users can select multiple secondary organizations while creating a course.
![image](https://user-images.githubusercontent.com/42185078/79867322-9fd63d80-83f7-11ea-9ecb-27691703038a.png)

- Staff users can edit secondary organizations in the course setting page.
![image](https://user-images.githubusercontent.com/42185078/79884491-a8863e00-840e-11ea-8b3d-70cd210d66d0.png)

