### PR TITLE
EDE-318: Take site prefix into account while validating max_length of name and domain

### DIFF
--- a/openedx/features/colaraz_features/api/serializers.py
+++ b/openedx/features/colaraz_features/api/serializers.py
@@ -13,8 +13,8 @@ from openedx.features.colaraz_features.helpers import (
 
 
 class SiteOrgSerializer(serializers.Serializer):
-    site_domain = DomainField(max_length=100)
-    site_name = serializers.CharField(max_length=50)
+    site_domain = DomainField(max_length=90)
+    site_name = serializers.CharField(max_length=40)
     site_theme = serializers.CharField(max_length=255, default=settings.DEFAULT_SITE_THEME)
     org_name = serializers.CharField(max_length=255)
     org_short_name = serializers.SlugField(max_length=255)


### PR DESCRIPTION
__Description:__
I forgot to adjust max_length restriction taking "courses" and "studio" prefixes into account in my previous PR, this PR fixes that.

I could not test it before as the bug is not reproducible locally, it only appears on stage.