### PR TITLE
EDE-318: provide a default value for optional fields so that error is not raised later on.

### DIFF
--- a/openedx/features/colaraz_features/api/serializers.py
+++ b/openedx/features/colaraz_features/api/serializers.py
@@ -14,12 +14,12 @@ from openedx.features.colaraz_features.helpers import (
 
 class SiteOrgSerializer(serializers.Serializer):
     site_domain = DomainField(max_length=90)
-    site_name = serializers.CharField(max_length=40)
+    site_name = serializers.CharField(max_length=40, required=False, default='')
     site_theme = serializers.CharField(max_length=255, default=settings.DEFAULT_SITE_THEME)
     org_name = serializers.CharField(max_length=255)
     org_short_name = serializers.SlugField(max_length=255)
     platform_name = serializers.CharField(max_length=255)
-    university_name = serializers.CharField(max_length=255, required=False)
+    university_name = serializers.CharField(max_length=255, required=False, default='')
     organizations = serializers.ListField(
         child=serializers.SlugField(max_length=255)
     )


### PR DESCRIPTION
__Description:__

This PR adds defaults for optional fields to avoid key errors later on. Also, I have marked `site_name` as it is not used anywhere.