### PR TITLE
fix bug for secondary organizations => use short_name instead name

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1065,7 +1065,7 @@ def settings_handler(request, course_key_string):
 
             # [COLARAZ_CUSTOM]
             # exclude primary organization from all organizations to get available options of secondary organizations
-            available_secondary_orgs = [org['name'] for org in get_organizations() if not (org['name'] == course_module.location.org)]
+            available_secondary_orgs = [org['short_name'] for org in get_organizations() if not (org['short_name'] == course_module.location.org)]
 
             # see if the ORG of this course can be attributed to a defined configuration . In that case, the
             # course about page should be editable in Studio

--- a/common/djangoapps/util/organizations_helpers.py
+++ b/common/djangoapps/util/organizations_helpers.py
@@ -105,7 +105,7 @@ def organizations_enabled():
     return settings.FEATURES.get('ORGANIZATIONS_APP', False)
 
 
-def get_secondary_org_names_of_course(course_id, primary_org_name):
+def get_secondary_org_names_of_course(course_id, primary_org_short_name):
     """
     Returns list of all secondary organizations names linked with the course.
     """
@@ -115,5 +115,5 @@ def get_secondary_org_names_of_course(course_id, primary_org_name):
     all_organizations = organizations_api.get_course_organizations(course_id)
 
     # exclude primary organization from the list
-    secondary_organizations = [org['name'] for org in all_organizations if not (org['name'] == primary_org_name)]
+    secondary_organizations = [org['short_name'] for org in all_organizations if not (org['short_name'] == primary_org_short_name)]
     return secondary_organizations


### PR DESCRIPTION
**Ticket is related to**: https://edlyio.atlassian.net/browse/EDE-358

**Description:**
Use organization **short_name** instead of **name** as edX is using the short_name for the primary organization.