### PR TITLE
Remove required sign (*) from secondary organizations input field.

### DIFF
--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -91,7 +91,7 @@ from openedx.core.djangolib.js_utils import (
                   <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
                 </li>
 
-                 <li class="field text required">
+                 <li class="field text">
                   <label for="new-course-secondary-org">${_("Secondary Organizations")}</label>
                   <select class="new-course-secondary-org" id="new-course-secondary-org" type="text" name="new-course-secondary-org" aria-describedby="tip-new-course-secondary-org tip-error-new-course-secondary-org" multiple>
                   </select>


### PR DESCRIPTION
Ticket Link: Bugfix for https://edlyio.atlassian.net/browse/EDE-358

**Description:** 

**Before:**
![image](https://user-images.githubusercontent.com/42185078/81037569-9e5b4980-8ebc-11ea-986f-a0ce4ba9e738.png)

**After:**
![image](https://user-images.githubusercontent.com/42185078/81037508-68b66080-8ebc-11ea-8ede-0a7d0d8e03af.png)
