### PR TITLE
EDE-443 Integrate course details page

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
@@ -97,56 +97,9 @@ from openedx.core.djangolib.markup import HTML
             </div>
         </div>
     </section>
-    <div class="discussion-sidebar">
-        <section class="discussion-widget">
-            <h3>Course Specifics</h3>
-            <ul class="course-specifics-list">
-                <li>
-                    <strong class="title">Starts</strong>
-                    <p>April 19, 2020 09:00 AM EST</p>
-                </li>
-                <li>
-                    <strong class="title">Duration</strong>
-                    <p>2 hours</p>
-                </li>
-                <li>
-                    <strong class="title">Language</strong>
-                    <p>English</p>
-                </li>
-            </ul>
-        </section>
-        <nav class="discussion-widget">
-            <ul class="discussion-share-list">
-                <li>
-                    <a href="#"><span class="fa fa-tag"></span></a>
-                </li>
-                <li>
-                    <a href="#"><span class="fa fa-share-alt"></span></a>
-                </li>
-                <li>
-                    <a href="#"><span class="fa fa-calendar"></span></a>
-                </li>
-            </ul>
-        </nav>
-        <section class="discussion-widget instructor-widget">
-            <h3>Instructor</h3>
-            <div class="btn-group">
-                <a href="#" class="menu-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="fa fa-ellipsis-v"></span>
-                </a>
-                <div class="dropdown-menu dropdown-menu-right">
-                  <ul>
-                    <li><a href="#"><span class="fa fa-pencil"></span> Edit</a></li>
-                  </ul>
-                </div>
-            </div>
-            <div class="image-frame">
-                <img src="${static.url('images/instructor.jpg')}" alt="Name Placeholder">
-            </div>
-            <h4 class="instructor-name">Name Placeholder</h4>
-            <span class="instructor-title">Title Placehodler</span>
-        </section>
-    </div>
+
+    <%include file="../course_details_sidebar.html" />
+
 </div>
 
 <%include file="_underscore_templates.html" />


### PR DESCRIPTION
This PR is related to [EDE-443](https://edlyio.atlassian.net/browse/EDE-443)

**PR Description**

The HTML portion responsible for course details displaying on the sidebar, has been removed. Now it is rendered from another file named **course_details_sidebar.html** which is located in **colaraz_theme** directory.

PR link for **colaraz_theme**
[https://github.com/colaraz/colaraz-theme/pull/13/](https://github.com/colaraz/colaraz-theme/pull/13/)


**Discussion Page**
![image](https://user-images.githubusercontent.com/42294172/81055736-be9dff00-8ee2-11ea-9abc-3f909d5a62df.png)
