### PR TITLE
filter seconday organizations

### DIFF
--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -4,9 +4,8 @@ from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-from util.organizations_helpers import get_organizations
+from util.organizations_helpers import get_organizations, filter_authorized_organizations_from_list
 
 
 class OrganizationListView(View):
@@ -20,14 +19,9 @@ class OrganizationListView(View):
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
         organizations = get_organizations()
-        # [COLARAZ_CUSTOM] 
+        # [COLARAZ_CUSTOM]
         # Restrict user from creating courses with non-authorized organizations
-        if not request.user.is_superuser:
-            site_orgs = configuration_helpers.get_current_site_orgs()
-            org_names_list = []
-            for org in organizations:
-                if (org["name"] in site_orgs) or (org["short_name"] in site_orgs):
-                    org_names_list.append(org["short_name"])
-        else:
-            org_names_list = [org["short_name"] for org in organizations]
-        return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')
+        org_names_list = filter_authorized_organizations_from_list(
+            organizations, request.user.is_superuser)
+        return HttpResponse(
+            dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')


### PR DESCRIPTION
**Ticket Link:**  https://edlyio.atlassian.net/browse/EDE-470

**Description:**
Alter secondary organization input options while creating and editing a course.

- **To admin user:**
  - Show all organizations as a secondary organization input option.
- **To normal staff user:**
  - Restrict user to only authorized site organizations (configured from site-config). 