### PR TITLE
Integrate Notifications API

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -642,6 +642,9 @@ COLARAZ_SUB_DOMAIN = ENV_TOKENS.get(
 COLARAZ_NAVIGATION_URLS = ENV_TOKENS.get(
     'COLARAZ_NAVIGATION_URLS'
 )
+COLARAZ_NOTIFICATIONS = ENV_TOKENS.get(
+    'COLARAZ_NOTIFICATIONS'
+)
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1152,6 +1152,9 @@ COLARAZ_NAVIGATION_URLS = ENV_TOKENS.get(
 COLARAZ_APP_LINKS_API_URL = ENV_TOKENS.get(
     'COLARAZ_APP_LINKS_API_URL'
 )
+COLARAZ_NOTIFICATIONS = ENV_TOKENS.get(
+    'COLARAZ_NOTIFICATIONS'
+)
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/openedx/features/colaraz_features/api/urls.py
+++ b/openedx/features/colaraz_features/api/urls.py
@@ -3,8 +3,12 @@ URL patterns for colaraz features application.
 """
 from django.conf.urls import url
 
-from openedx.features.colaraz_features.api.views import SiteOrgViewSet
+from openedx.features.colaraz_features.api.views import (
+    SiteOrgViewSet,
+    NotificationHandlerApiView,
+)
 
 urlpatterns = [
-    url(r'^site-org/', SiteOrgViewSet.as_view({'post': 'create'}))
+    url(r'^site-org/', SiteOrgViewSet.as_view({'post': 'create'})),
+    url(r'^notifications/(?P<api_method>\D+)', NotificationHandlerApiView.as_view(), name="notifications_handler"),
 ]

--- a/openedx/features/colaraz_features/api/views.py
+++ b/openedx/features/colaraz_features/api/views.py
@@ -1,11 +1,24 @@
 """
 Views for colaraz API.
 """
+import json
+import logging
+import requests
+from six.moves.urllib.parse import urlencode
+
+from django.conf import settings
+
 from rest_framework import viewsets, status
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from openedx.features.colaraz_features.api import serializers
 
+LOGGER = logging.getLogger(__name__)
+API_METHODS = {
+    'fetch': 'METHOD_FETCH_NOTIFICATIONS',
+    'mark': 'METHOD_MARK_NOTIFICATIONS',
+}
 
 class SiteOrgViewSet(viewsets.ViewSet):
     """
@@ -23,3 +36,43 @@ class SiteOrgViewSet(viewsets.ViewSet):
             serializer.create(serializer.validated_data)
 
         return Response(serializer.validated_data, status=status.HTTP_201_CREATED)
+
+
+class NotificationHandlerApiView(APIView):
+    """
+    APIView to fetch notifications and mark them as read.
+    """
+
+    def get(self, request, api_method, format=None):
+        """
+        This method uses Colaraz's Notifications API to fetch and mark notifications
+        and returns data sent by API in json format.
+        """
+        elgg_id = request.user.colaraz_profile.elgg_id
+        api_details = getattr(settings, 'COLARAZ_NOTIFICATIONS')
+        method_key = API_METHODS.get(api_method, None)
+
+        if api_details and elgg_id and method_key:
+            api_url = api_details.get('API_URL')
+            query_params = urlencode({
+                'api_key': api_details.get('API_KEY'),
+                'guid': elgg_id,
+                'method': api_details.get(method_key),
+            })
+
+            resp = requests.get(api_url, params=query_params)
+            if resp.status_code == status.HTTP_200_OK:
+                json_data = json.loads(resp.content)
+                if json_data.get('status') == 0:
+                    return Response(json_data, status=status.HTTP_200_OK)
+                else:
+                    LOGGER.error('Notifications API gave error: {}'.format(json_data.get('message')))
+                    return Response(json_data, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                LOGGER.error('Notifications API returned {} status'.format(resp.status_code))
+        else:
+            LOGGER.error('Notifications API parameters are not complete or configured properly')
+        return Response(
+            {'message': 'Notifications API is not configured properly'},
+            status=status.HTTP_400_BAD_REQUEST
+        )


### PR DESCRIPTION
### Story Link
[EDE-457](https://edlyio.atlassian.net/browse/EDE-457)
### Description 
Integrating Colaraz's Site Notifications API with open edX.
Main use-cases:
1) Refresh and populate notifications from API endpoint to front-end navbar
2) Once clicked on the navbar mark the unread notifications as read.

![image](https://user-images.githubusercontent.com/42243411/82550231-a0d5c880-9b77-11ea-8d89-0974940860e4.png)
