### PR TITLE
COL-84 Integrate course header

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -12,6 +12,7 @@ from django.template.defaultfilters import escapejs
 from django.urls import reverse
 
 from django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG, SHOW_REVIEWS_TOOL_FLAG
@@ -44,8 +45,12 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
 
 
     <header class="page-info-header">
+        <%
+            course_overview = CourseOverview.get_from_id(course.id)
+            course_image_url = course_overview.course_image_url
+        %>
         <div class="image-frame">
-            <img src="${static.url('images/course.jpg')}" alt="Autodesk Maya">
+            <img src="${course_image_url if not '/static/studio/images/pencils.jpg' in course_image_url else static.url('images/course.jpg')}" alt="${course_overview.display_name_with_default}">
         </div>
         <div class="content-area">
             <div class="form-actions">
@@ -77,7 +82,7 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
                 % endif
             </div>
             <h2>${course.display_name_with_default}</h2>
-            <h3>Organization</h3>
+            <h3>${course_overview.display_org_with_default}</h3>
         </div>
     </header>
     <div class="page-content">


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-84](https://edlyio.atlassian.net/browse/COL-84)

**PR Description**
Previously the course header on course details page shows static data. Now it has been integrated to display dynamic data according to the course.
**If the image is set**
![image](https://user-images.githubusercontent.com/42294172/83875771-239e7c00-a751-11ea-8620-7a0cf497ddb7.png)

**If the image is not set**
![image](https://user-images.githubusercontent.com/42294172/83875545-b559b980-a750-11ea-8dc7-1afed4806b54.png)
