### PR TITLE
COL-99 fix course default image issue

### DIFF
--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -226,7 +226,7 @@ class MongoCourseImageTestCase(ModuleStoreTestCase):
     def test_get_image_url(self):
         """Test image URL formatting."""
         course = CourseFactory.create(org='edX', course='999')
-        self.assertEquals(course_image_url(course), '/c4x/edX/999/asset/{0}'.format(course.course_image))
+        self.assertEquals(course_image_url(course), '/static/' + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL)
 
     def test_non_ascii_image_name(self):
         # Verify that non-ascii image names are cleaned

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1595,7 +1595,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
 
     def test_course_image(self):
         url = course_image_url(self.course)
-        self.assertTrue(url.startswith('/c4x/'))
+        self.assertTrue(url.startswith('/static/'))
 
         self.course.static_asset_path = "toy_course_dir"
         url = course_image_url(self.course)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -981,7 +981,7 @@ STATICFILES_DIRS = [
 ]
 
 FAVICON_PATH = 'images/favicon.ico'
-DEFAULT_COURSE_ABOUT_IMAGE_URL = 'images/pencils.jpg'
+DEFAULT_COURSE_ABOUT_IMAGE_URL = '/colaraz/images/course_image.png'
 
 # User-uploaded content
 MEDIA_ROOT = '/edx/var/edxapp/media/'

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -347,7 +347,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
         course_overview = CourseOverview._create_or_update(course)  # pylint: disable=protected-access
         self.assertEqual(course_overview.lowest_passing_grade, None)
 
-    @ddt.data((ModuleStoreEnum.Type.mongo, 4, 4), (ModuleStoreEnum.Type.split, 3, 4))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 4, 5), (ModuleStoreEnum.Type.split, 3, 4))
     @ddt.unpack
     def test_versioning(self, modulestore_type, min_mongo_calls, max_mongo_calls):
         """
@@ -702,31 +702,26 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
             }
         )
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_cdn(self, modulestore_type):
+    def test_cdn(self):
         """
         Test that we return CDN prefixed URLs if it is enabled.
         """
-        with self.store.default_store(modulestore_type):
-            course = CourseFactory.create(default_store=modulestore_type)
-            overview = CourseOverview.get_from_id(course.id)
+        course = CourseFactory.create()
+        overview = CourseOverview.get_from_id(course.id)
 
-            # First the behavior when there's no CDN enabled...
-            AssetBaseUrlConfig.objects.all().delete()
-            if modulestore_type == ModuleStoreEnum.Type.mongo:
-                expected_path_start = "/c4x/"
-            elif modulestore_type == ModuleStoreEnum.Type.split:
-                expected_path_start = "/asset-v1:"
+        # First the behavior when there's no CDN enabled...
+        AssetBaseUrlConfig.objects.all().delete()
+        expected_path_start = "/static"
 
-            for url in overview.image_urls.values():
-                self.assertTrue(url.startswith(expected_path_start))
+        for url in overview.image_urls.values():
+            self.assertTrue(url.startswith(expected_path_start))
 
-            # Now enable the CDN...
-            AssetBaseUrlConfig.objects.create(enabled=True, base_url='fakecdn.edx.org')
-            expected_cdn_url = "//fakecdn.edx.org" + expected_path_start
+        # Now enable the CDN...
+        AssetBaseUrlConfig.objects.create(enabled=True, base_url='fakecdn.edx.org')
+        expected_cdn_url = "//fakecdn.edx.org" + expected_path_start
 
-            for url in overview.image_urls.values():
-                self.assertTrue(url.startswith(expected_cdn_url))
+        for url in overview.image_urls.values():
+            self.assertTrue(url.startswith(expected_cdn_url))
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_cdn_with_external_image(self, modulestore_type):

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -10,6 +10,7 @@ from six import text_type
 from xmodule.assetstore.assetmgr import AssetManager
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
+from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import modulestore
 
 
@@ -32,6 +33,13 @@ def course_image_url(course, image_key='course_image'):
         url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
     else:
         loc = StaticContent.compute_location(course.id, getattr(course, image_key))
+        if getattr(course, image_key).endswith('images_course_image.jpg'):
+            try:
+                AssetManager.find(loc)
+            except NotFoundError:
+                url = '/static/' + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
+                return url
+
         url = StaticContent.serialize_asset_key_with_slash(loc)
 
     return url

--- a/openedx/core/lib/tests/test_courses.py
+++ b/openedx/core/lib/tests/test_courses.py
@@ -3,6 +3,7 @@ Tests for functionality in openedx/core/lib/courses.py.
 """
 
 import ddt
+from django.conf import settings
 from django.test.utils import override_settings
 
 from xmodule.modulestore import ModuleStoreEnum
@@ -29,7 +30,7 @@ class CourseImageTestCase(ModuleStoreTestCase):
         """Test image URL formatting."""
         course = CourseFactory.create()
         self.verify_url(
-            unicode(course.id.make_asset_key('asset', course.course_image)),
+            '/static/' + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL,
             course_image_url(course)
         )
 

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -50,7 +50,7 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
             course_image_url = course_overview.course_image_url
         %>
         <div class="image-frame">
-            <img src="${course_image_url if not '/static/studio/images/pencils.jpg' in course_image_url else static.url('images/course.jpg')}" alt="${course_overview.display_name_with_default}">
+            <img src="${course_image_url}" alt="${course_overview.display_name_with_default}">
         </div>
         <div class="content-area">
             <div class="form-actions">


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-99](https://edlyio.atlassian.net/browse/COL-99)

**Description**
By default, if we don't set up an edX course image it comes up with a broken image URL. In this PR we have added a default course functionality. If a staff user doesn't set up a course image for the first time, a default course image will be shown.

**Dependency**
The PR is dependent on this PR [https://github.com/colaraz/colaraz-theme/pull/51](https://github.com/colaraz/colaraz-theme/pull/51)
In the PR, mentioned above, default course image files have been added.
**Reference PRs**
1. [https://github.com/ucsd-ets/edx-platform/pull/274/](https://github.com/ucsd-ets/edx-platform/pull/274/)
2. [https://github.com/ucsd-ets/edx-platform/pull/275/](https://github.com/ucsd-ets/edx-platform/pull/275/)
3. [https://github.com/ucsd-ets/edx-platform/pull/287/](https://github.com/ucsd-ets/edx-platform/pull/287/)
4. [https://github.com/ucsd-ets/edx-platform/pull/293/](https://github.com/ucsd-ets/edx-platform/pull/293/)
