### PR TITLE
COL-111 Fix add response submit button

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1127,7 +1127,11 @@
             cancelButton = document.getElementById('new-link-image-cancel');
 
             okButton.onclick = function() { return close(false); };
-            cancelButton.onclick = function() { return close(true); };
+            cancelButton.onclick = function() {
+                submitButton = document.getElementsByClassName('discussion-submit-post');
+                $(submitButton).attr('disabled', true);
+                return close(true);
+            };
 
             if (imageUploadHandler) {
               var descriptionFieldHasContent,
@@ -1162,6 +1166,8 @@
                       urlAndDescriptionFieldHasContent = (descriptionFieldHasContent && urlFieldHasContent);
 
                       if (imageAndDescriptionFieldHasContent || urlAndDescriptionFieldHasContent) {
+                        submitButton = document.getElementsByClassName('discussion-submit-post');
+                        $(submitButton).removeAttr('disabled');
                         okButton.disabled = false;
                       }
                     }


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-111](https://edlyio.atlassian.net/browse/COL-111)

**PR Description**
Previously, when we try to respond a comment in a thread just using an image the submit button wasn't enabled. 
Now this behavior has been fixed.


**Old Behavior**
![image](https://user-images.githubusercontent.com/42294172/85255688-336dce00-b47c-11ea-9c42-5a6700beb6fa.png)

**New Behavior**
![image](https://user-images.githubusercontent.com/42294172/85256067-eccca380-b47c-11ea-9b3e-b386fc58726f.png)
