### PR TITLE
COL-124 Rollback to edX default functionality of posts submit button

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -65,8 +65,7 @@
                 'click .add-response-btn': 'scrollToAddResponse',
                 'keydown .wmd-button': function(event) {
                     return DiscussionUtil.handleKeypressInToolbar(event);
-                },
-                'input .discussion-reply-new .wmd-input': 'toggleResponseSubmitButton'
+                }
             };
 
             DiscussionThreadView.prototype.$ = function(selector) {
@@ -345,11 +344,6 @@
 
             DiscussionThreadView.prototype.endorseThread = function() {
                 return this.model.set('endorsed', this.$el.find('.action-answer.is-checked').length > 0);
-            };
-
-            DiscussionThreadView.prototype.toggleResponseSubmitButton = function(event) {
-                var postButton = $('.discussion-submit-post');
-                postButton.attr('disabled', !(event.target.value.length));
             };
 
             DiscussionThreadView.prototype.submitComment = function(event) {

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -133,8 +133,6 @@
                 'keypress .forum-new-post-form input:not(.wmd-input)': function(event) {
                     return DiscussionUtil.ignoreEnterKey(event);
                 },
-                'input .forum-new-post-form .wmd-input ': 'toggleSubmitButton',
-                'input .forum-new-post-form #discussion-forum-title': 'toggleSubmitButton',
                 'submit .forum-new-post-form': 'createPost',
                 'change .post-option-input': 'postOptionChange',
                 'change .js-group-select': 'groupOptionChange',
@@ -144,18 +142,6 @@
                 'keydown .wmd-button': function(event) {
                     return DiscussionUtil.handleKeypressInToolbar(event);
                 }
-            };
-
-            NewPostView.prototype.toggleSubmitButton = function () {
-              var submitButtonDisabled = true,
-                titleLength = $.trim(this.$('#discussion-forum-title').val()).length,
-                bodyLength = $.trim(this.$('.wmd-input').val()).length;
-
-              if (titleLength > 0 && bodyLength > 0){
-                  submitButtonDisabled = false;
-              }
-
-              this.$('.submit').prop('disabled', submitButtonDisabled);
             };
 
             NewPostView.prototype.toggleGroupDropdown = function($target) {

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -52,7 +52,6 @@
             ThreadResponseView.prototype.events = {
                 'click .discussion-submit-comment': 'submitComment',
                 'focus .wmd-input': 'showEditorChrome',
-                'input .wmd-input': 'toggleCommentSubmitButton'
             };
 
             ThreadResponseView.prototype.$ = function(selector) {
@@ -180,13 +179,6 @@
                 this.focusToTheCommentResponse(view.$el.closest('.forum-response'));
                 DiscussionUtil.typesetMathJax(view.$el.find('.response-body'));
                 return view;
-            };
-
-            ThreadResponseView.prototype.toggleCommentSubmitButton = function(event) {
-              var id = event.target.id.split('-').slice(-1)[0],
-                querySelector = 'form[data-id="' + id + '"] .discussion-submit-comment',
-                commentButton = document.querySelector(querySelector);
-                commentButton.disabled = !($.trim(event.target.value).length);
             };
 
             ThreadResponseView.prototype.submitComment = function(event) {

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -69,7 +69,7 @@
         <% } %>
     </div>
     <div>
-        <button type="submit" class="btn btn-primary submit" disabled><%- gettext('Submit') %></button>
+        <button type="submit" class="btn btn-primary submit"><%- gettext('Submit') %></button>
         <button type="button" class="btn btn-outline-primary cancel"><%- gettext('Cancel') %></button>
     </div>
 </form>

--- a/common/static/common/templates/discussion/thread-response.underscore
+++ b/common/static/common/templates/discussion/thread-response.underscore
@@ -15,7 +15,7 @@
                 <div class="comment-body" id="add-new-comment-<%- wmdId %>" data-id="<%- wmdId %>"
                 data-placeholder="<%- gettext('Add a comment') %>"></div>
                 <div class="comment-post-control">
-                    <button class="btn btn-primary discussion-submit-comment control-button" disabled><%- gettext("Submit") %></button>
+                    <button class="btn btn-primary discussion-submit-comment control-button"><%- gettext("Submit") %></button>
                 </div>
             </form>
         <% } %>

--- a/common/static/common/templates/discussion/thread.underscore
+++ b/common/static/common/templates/discussion/thread.underscore
@@ -61,7 +61,7 @@
                 <ul class="discussion-errors"></ul>
                 <div class="reply-body" data-id="<%- id %>"></div>
                 <div class="reply-post-control">
-                    <button class="btn btn-outline-primary discussion-submit-post control-button" disabled><%- gettext("Submit") %></button>
+                    <button class="btn btn-outline-primary discussion-submit-post control-button"><%- gettext("Submit") %></button>
                 </div>
             </form>
             <% } %>

--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1127,50 +1127,17 @@
             cancelButton = document.getElementById('new-link-image-cancel');
 
             okButton.onclick = function() { return close(false); };
-            cancelButton.onclick = function() {
-                submitButton = document.getElementsByClassName('discussion-submit-post');
-                $(submitButton).attr('disabled', true);
-                return close(true);
-            };
+            cancelButton.onclick = function() { return close(true); };
 
             if (imageUploadHandler) {
-              var descriptionFieldHasContent,
-                valueOfUrlField,
-                urlFieldHasContent,
-                uploadFieldHasContent,
-                urlAndDescriptionFieldHasContent,
-                imageAndDescriptionFieldHasContent;
-                okButton.disabled = true;
                 var startUploadHandler = function() {
-                    document.getElementById('file-upload').onchange = function(event) {
+                    document.getElementById('file-upload').onchange = function() {
                         imageUploadHandler(this, urlInput);
                         urlInput.focus();
 
-                        descriptionFieldHasContent = $.trim(descInput.value).length;
-                        okButton.disabled = !(descriptionFieldHasContent && event.target.value.length);
                         // Ensures that a user can update their file choice.
                         startUploadHandler();
                     };
-
-                    urlInput.oninput = toggleSubmitButton;
-
-                    descInput.oninput = toggleSubmitButton;
-
-                    function toggleSubmitButton() {
-                      okButton.disabled=true;
-                      descriptionFieldHasContent = $.trim(descInput.value).length;
-                      valueOfUrlField = $.trim(urlInput.value);
-                      urlFieldHasContent = valueOfUrlField.replace(/^https?:\/\//i, '').length;
-                      uploadFieldHasContent = document.getElementById('file-upload').value.length;
-                      imageAndDescriptionFieldHasContent = (descriptionFieldHasContent && uploadFieldHasContent);
-                      urlAndDescriptionFieldHasContent = (descriptionFieldHasContent && urlFieldHasContent);
-
-                      if (imageAndDescriptionFieldHasContent || urlAndDescriptionFieldHasContent) {
-                        submitButton = document.getElementsByClassName('discussion-submit-post');
-                        $(submitButton).removeAttr('disabled');
-                        okButton.disabled = false;
-                      }
-                    }
                 };
                 startUploadHandler();
                 document.getElementById('file-upload-proxy').onclick = function() {


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-124](https://edlyio.atlassian.net/browse/COL-124)

**PR Description**
Maintaining a disabled submit button feature was causing some other issues. So, in this PR all changes related to that feature have been removed. 

**Reference PR's**
Changes related to these PR's have been removed.
[https://github.com/edly-io/edx-platform/pull/27/files](https://github.com/edly-io/edx-platform/pull/27/files)
[https://github.com/edly-io/edx-platform/pull/28/files](https://github.com/edly-io/edx-platform/pull/28/files)
[https://github.com/edly-io/edx-platform/pull/29/files](https://github.com/edly-io/edx-platform/pull/29/files)
[https://github.com/colaraz/edx-platform/pull/68/files](https://github.com/colaraz/edx-platform/pull/68/files)