### PR TITLE
COL-122 Replace author links on posts with simple text

### DIFF
--- a/common/static/common/js/discussion/views/discussion_content_view.js
+++ b/common/static/common/js/discussion/views/discussion_content_view.js
@@ -493,12 +493,13 @@
             };
 
             DiscussionContentShowView.prototype.getAuthorDisplay = function() {
-                return _.template($('#post-user-display-template').html())({
+                var author_link = _.template($('#post-user-display-template').html())({
                     username: this.model.get('username') || null,
-                    user_url: this.model.get('user_url'),
+                    user_url: '#',
                     is_community_ta: this.model.get('community_ta_authored'),
                     is_staff: this.model.get('staff_authored')
                 });
+                return author_link.replace('<a', '<a style="pointer-events: none;"');
             };
 
             DiscussionContentShowView.prototype.getEndorserDisplay = function() {


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-122](https://edlyio.atlassian.net/browse/COL-122)

**PR Description**
We are no more using edX user profile in colaraz. But on the discussion page there are still some links referring to profile pages. In this PR these links have been deactivated. They are no more clickable.