### PR TITLE
COL-159 Add follow post functionality

### DIFF
--- a/common/static/common/templates/discussion/thread.underscore
+++ b/common/static/common/templates/discussion/thread.underscore
@@ -36,8 +36,15 @@
                         Public
                     </li>
                     <li class="actions-item">
-                        <button class="btn-link action-button action-follow is-checked" role="checkbox" aria-checked="true">
+                        <button class="btn-link action-button action-follow <% if(window.IS_POST_SUBSCRIBED) { %>is-checked<% }%>"
+                        role="checkbox"
+                        <% if(window.IS_POST_SUBSCRIBED) { %>aria-checked="true"<% } else { %>aria-checked="false" <% }%>>
                             <span class="sr">Follow</span>
+                            <span class="action-label" aria-hidden="true">
+                                <span class="label-unchecked">Follow</span>
+                                <span class="label-checked">Unfollow</span>
+                            </span>
+
                             <span class="action-icon">
                                 <span class="icon fa fa-star" aria-hidden="true"></span>
                             </span>

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -4,6 +4,18 @@
 
 <script type="text/javascript">
   window.PLATFORM_NAME = "${settings.PLATFORM_NAME | n, js_escaped_string}";
+
+  <%
+    single_post_id = context.get('annotated_content_info').keys()[0]
+    is_post_subscribed = context.get('annotated_content_info').get(single_post_id).get('subscribed')
+  %>
+
+  % if is_post_subscribed:
+    window.IS_POST_SUBSCRIBED = true;
+  % else:
+    window.IS_POST_SUBSCRIBED = false;
+  % endif
+
   % if settings.FEATURES.get('ENABLE_DISCUSSION_HOME_PANEL', False):
     window.ENABLE_DISCUSSION_HOME_PANEL = true;
   % else:


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-159](https://edlyio.atlassian.net/browse/COL-159)

**PR Description**
Because of the redesigning of `discussion` page, the `follow post` functionality was broken. Now it has been fixed.

**Related PR**
This PR is dependent on the PR from `colaraz/edx theme`
[https://github.com/colaraz/colaraz-theme/pull/77](https://github.com/colaraz/colaraz-theme/pull/77)