### PR TITLE
COL-174 Fix first time vote button status

### DIFF
--- a/common/static/common/js/discussion/views/discussion_content_view.js
+++ b/common/static/common/js/discussion/views/discussion_content_view.js
@@ -286,9 +286,10 @@
                             ngettext('{numVotes} Vote', '{numVotes} Votes', numVotes),
                             {numVotes: numVotes});
                         button.find('.vote-count').empty().text(votesText);
-
                         if (this.$el.hasClass('thread-content-wrapper')) {
+                            let isVoteCasted = button.attr('aria-checked');
                             button = this.$el.closest('.thread-wrapper').find('.thread-responses-wrapper button.action-vote');
+                            button.attr('aria-checked', isVoteCasted);
                             button.find('.js-sr-vote-count').empty().text(
                                 edx.StringUtils.interpolate(votesCountMsg, {numVotes: numVotes})
                             );


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-174](https://edlyio.atlassian.net/browse/COL-174)

**PR Description**
Previously, we weren't setting the first time status of the `voting` button. It was always set to `false`. Means, whenever we clicked on that button, the first voting request was always of `upvote`. This thing has been fixed in this PR.