### PR TITLE
Use var to make js variable

### DIFF
--- a/common/static/common/js/discussion/views/discussion_content_view.js
+++ b/common/static/common/js/discussion/views/discussion_content_view.js
@@ -287,7 +287,7 @@
                             {numVotes: numVotes});
                         button.find('.vote-count').empty().text(votesText);
                         if (this.$el.hasClass('thread-content-wrapper')) {
-                            let isVoteCasted = button.attr('aria-checked');
+                            var isVoteCasted = button.attr('aria-checked');
                             button = this.$el.closest('.thread-wrapper').find('.thread-responses-wrapper button.action-vote');
                             button.attr('aria-checked', isVoteCasted);
                             button.find('.js-sr-vote-count').empty().text(


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-174](https://edlyio.atlassian.net/browse/COL-174)

**PR Description**
Using `let` to make js variable was causing build failure issues. Now it has been replaced with `var`.