### PR TITLE
COL-188 Remove username word from certificates tab

### DIFF
--- a/lms/static/js/certificates/models/certificate_exception.js
+++ b/lms/static/js/certificates/models/certificate_exception.js
@@ -28,8 +28,8 @@
                 },
                 validate: function(attrs) {
                     if (!str.trim(attrs.user_name) && !str.trim(attrs.user_email)) {
-                        return gettext('Student username/email field is required and can not be empty. ' +
-                            'Kindly fill in username/email and then press "Add to Exception List" button.');
+                        return gettext('Student email address field is required and can not be empty. ' +
+                            'Kindly fill in email address and then press "Add to Exception List" button.');
                     }
                 }
             });

--- a/lms/static/js/certificates/models/certificate_invalidation.js
+++ b/lms/static/js/certificates/models/certificate_invalidation.js
@@ -25,8 +25,8 @@
                 validate: function(attrs) {
                     if (!str.trim(attrs.user)) {
                         // A username or email must be provided for certificate invalidation
-                        return gettext('Student username/email field is required and can not be empty. ' +
-                            'Kindly fill in username/email and then press "Invalidate Certificate" button.');
+                        return gettext('Student email address field is required and can not be empty. ' +
+                            'Kindly fill in email address and then press "Invalidate Certificate" button.');
                     }
                 }
             });

--- a/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
@@ -12,7 +12,6 @@
         <textarea class="notes-field" id="certificate-invalidation-notes" rows="10"></textarea>
     </div>
     <br/>
-    
     <button type="button" class="btn-blue" id="invalidate-certificate"><%- gettext('Invalidate Certificate') %></button>
 </div>
 

--- a/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
@@ -4,7 +4,7 @@
     <div class="">
         <label for="certificate-exception" class="sr"><%- gettext("Student email or username") %></label>
         <input class="student-username-or-email" id="certificate-exception" type="text" placeholder="<%- gettext('Student email or username') %>">
-        
+
         <label for="notes" class="sr"><%- gettext('Free text notes') %></label>
         <textarea class="notes-field" id="notes" rows="10" placeholder="<%- gettext('Free text notes') %>"></textarea>
     </div>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-188](https://edlyio.atlassian.net/browse/COL-188)

**PR Description**
Previously, when we removed `username` from the instructor dashboard, the certificates weren't enabled that's why we missed this page. Now the certificates page has also been updated.


**Related PR**
[https://github.com/colaraz/colaraz-theme/pull/93](https://github.com/colaraz/colaraz-theme/pull/93)