### PR TITLE
COL-181 Revert is_staff modifications for certificates tab

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -109,15 +109,8 @@ def instructor_dashboard_2(request, course_id):
 
     course = get_course_by_id(course_key, depth=0)
 
-    current_org = request.user.colaraz_profile.site_identifier
-    has_admin_access = (request.user.is_staff
-                        or request.user.courseaccessrole_set.filter(
-                        (Q(course_id=CourseKey.from_string(course_id))
-                        | Q(course_id=CourseKeyField.Empty, org__iexact=current_org))
-                        & Q(role__in=['instructor', 'staff']) ).exists())
-
     access = {
-        'admin': has_admin_access,
+        'admin': request.user.is_staff,
         'instructor': bool(has_access(request.user, 'instructor', course)),
         'finance_admin': CourseFinanceAdminRole(course_key).has_user(request.user),
         'sales_admin': CourseSalesAdminRole(course_key).has_user(request.user),


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-181](https://edlyio.atlassian.net/browse/COL-181)

**PR Description**

In the PR [https://github.com/colaraz/edx-platform/pull/103](https://github.com/colaraz/edx-platform/pull/103)
We did some modifications which were responsible to show certificate tab to the instructor of the course. But in the QA, we identified that these modifications are not enough to make the options (shown in the certificates tab) fully functional for the user whose role is an instructor. So for the release purposes, we are reverting these incomplete changes.