### PR TITLE
COL-181 Replace is_staff privileges

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -40,6 +40,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -52,6 +52,7 @@ from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackC
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.core.lib.xblock_utils import wrap_xblock
+from openedx.features.colaraz_features.helpers import has_admin_access
 from shoppingcart.models import Coupon, CourseRegCodeItem, PaidCourseRegistration
 from student.models import CourseEnrollment
 from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole, CourseStaffRole, CourseInstructorRole
@@ -110,7 +111,7 @@ def instructor_dashboard_2(request, course_id):
     course = get_course_by_id(course_key, depth=0)
 
     access = {
-        'admin': request.user.is_staff,
+        'admin': request.user.is_staff or has_admin_access(request, course_key), # [COLARAZ_CUSTOM]
         'instructor': bool(has_access(request.user, 'instructor', course)),
         'finance_admin': CourseFinanceAdminRole(course_key).has_user(request.user),
         'sales_admin': CourseSalesAdminRole(course_key).has_user(request.user),


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-181](https://edlyio.atlassian.net/browse/COL-181)

**PR Description**
Previously `Certifications` tab functionality was dependent on `is_staff`. Now this thing has been made compatible to Colaraz Roles.