### PR TITLE
add token in url of xblock api

### DIFF
--- a/openedx/features/colaraz_features/api/urls.py
+++ b/openedx/features/colaraz_features/api/urls.py
@@ -17,5 +17,5 @@ urlpatterns = [
     url(r'^notifications/(?P<api_method>\D+)', NotificationHandlerApiView.as_view(), name="notifications_handler"),
     url(r'^job-alerts/(?P<api_method>\D+)', JobAlertsHandlerApiView.as_view(), name="job_alerts_handler"),
     url(r'^course/{}'.format(settings.COURSE_ID_PATTERN), CourseOutlineView.as_view(), name="course_outline"),
-    url(r'^xblock/{}$'.format(settings.USAGE_KEY_PATTERN), CourseXBlockApi.as_view(), name="course_xblock"),
+    url(r'^xblock/{}/$'.format(settings.USAGE_KEY_PATTERN), CourseXBlockApi.as_view(), name="course_xblock"),
 ]

--- a/openedx/features/colaraz_features/api/views.py
+++ b/openedx/features/colaraz_features/api/views.py
@@ -25,6 +25,7 @@ from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.courseware.module_render import get_module, get_module_by_usage_id, get_module_for_descriptor
 from openedx.features.colaraz_features.api import serializers
+from openedx.features.colaraz_features.api.validators import TokenBasedAuthentication
 from openedx.features.course_experience.utils import get_course_outline_block_tree
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -204,7 +205,7 @@ class CourseOutlineView(APIView):
 
 
 class CourseXBlockApi(APIView):
-    authentication_classes = (OAuth2Authentication,)
+    authentication_classes = (TokenBasedAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, usage_key_string):


### PR DESCRIPTION
Ticket:
https://edlyio.atlassian.net/browse/COL-235
Description:
Added auth token in url as query parameter which is being verified and authenticated via custom authenticator.
Example url format:
{domain_name}/colaraz/api/v1/xblock/{block_usage_id}/?token=AIlgBSplKjY8XNkxtcN45aABemoTnI