### PR TITLE
Resolved UnicodeEncodeError

### DIFF
--- a/openedx/features/colaraz_features/auth_backend.py
+++ b/openedx/features/colaraz_features/auth_backend.py
@@ -56,7 +56,7 @@ class ColarazIdentityServer(IdentityServer3):
                 raise AuthException("Colaraz", "Your account belongs to {}".format(user_site_domain))
 
             details = {
-                "fullname": "{} {}".format(response["firstName"], response["lastName"]),
+                "fullname": u"{} {}".format(response["firstName"], response["lastName"]).encode("ascii", "ignore"),
                 "email": response["email"],
                 "first_name": response["firstName"],
                 "last_name": response["lastName"],


### PR DESCRIPTION
**Resolved UnicodeEncodeError**

Story: [COL-263](https://edlyio.atlassian.net/browse/COL-263?atlOrigin=eyJpIjoiYjNhODU3YmQzOTExNGZhZTliMmNkMjNlMGI5ZmFlYmYiLCJwIjoiaiJ9)

Issue: `UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 6: ordinal not in range(128)`

**Description:**
Error occurred during Unicode conversion to String so I have ignored all the unicode characters which might cause issue.