### PR TITLE
COL-285 Display grades in percentage in grade report

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -366,7 +366,7 @@ class CourseGradeReport(object):
             if assignment_average is not None:
                 grade_results.append([assignment_average])
 
-        return [course_grade.percent] + _flatten(grade_results)
+        return ["{}%".format(course_grade.percent*100)] + _flatten(grade_results)
 
     def _user_subsection_grades(self, course_grade, subsection_headers):
         """


### PR DESCRIPTION
In Grade Report, grades were showing in decimal values, so it is changed to display in percentage. 