### PR TITLE
fix: upload file limit

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -678,7 +678,7 @@ derived_collection_entry('DEFAULT_TEMPLATE_ENGINE', 'DIRS')
 AUTHENTICATION_BACKENDS = [
     'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
 ]
-STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
+STUDENT_FILEUPLOAD_MAX_SIZE = 500 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
 # Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)


### PR DESCRIPTION
Changing limit in the SGA block wasn't working as nginx was blocking the larger files, eventually, we have to override this limit in the edx-platform.