### PR TITLE
Wrong format for CSV files on download issue fixed

### DIFF
--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -17,3 +17,12 @@
   %endif
 % endfor
 </div>
+
+<script>
+  $(function(){
+    var ext = '.csv';
+    $('a[href*="' + ext + '"]').each(function() {
+      $(this).prop('download', this.href.split('/').pop().split('.')[0] + ext);
+    });
+  });
+</script>


### PR DESCRIPTION
CSV files were changing to xls on download. Issue is fixed and now CSVs will be downloaded with correct format.